### PR TITLE
Drop bash from layout

### DIFF
--- a/w5/w5-s6-c2-modules-et-chemins.ipynb
+++ b/w5/w5-s6-c2-modules-et-chemins.ipynb
@@ -121,7 +121,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "```bash\n",
+    "```\n",
     "$ cd /le/repertoire/ou/vous/etes/\n",
     "/le/repertoire/ou/vous/etes $ python3 /le/repertoire/du/script/run.py\n",
     "le répertoire courant est /le/repertoire/ou/vous/etes\n",


### PR DESCRIPTION
The end of block is incorrectly colored otherwise (after the single quote).