### PR TITLE
Allow one to execute code

### DIFF
--- a/w6/w6-s3-c3-dataclasses.ipynb
+++ b/w6/w6-s3-c3-dataclasses.ipynb
@@ -27,13 +27,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Comme cette capacité n'est disponible qu'à partir de Python 3.7 et que le cours est basé sur Python 3.6, nous n'aurons pas la possibilité de manipuler directement ce nouveau concept. Voici toutefois quelques exemples pour vous donner un aperçu de ce qu'on peut faire de cette notion."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "### Aperçu"
    ]
   },
@@ -47,24 +40,28 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "```python\n",
-    ">>> from dataclasses import dataclass\n",
-    ">>>\n",
-    ">>> @dataclass\n",
-    "... class Personne:\n",
-    "...     nom: str\n",
-    "...     age: int\n",
-    "...     email: str = \"\"\n",
-    "...\n",
-    ">>> personne = Personne(nom='jean', age=12)\n",
-    ">>>\n",
-    ">>> print(personne)\n",
-    "Personne(nom='jean', age=12, email='')\n",
-    ">>>\n",
-    "```"
+    "from dataclasses import dataclass\n",
+    "\n",
+    "@dataclass\n",
+    "class Personne:\n",
+    "    nom: str\n",
+    "    age: int\n",
+    "    email: str = \"\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "personne = Personne(nom='jean', age=12)\n",
+    "print(personne)"
    ]
   },
   {
@@ -82,50 +79,63 @@
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "```python\n",
-    ">>> import sys; print(sys.version)\n",
-    "3.7.0 (default, Jun 29 2018, 20:14:27)\n",
-    "[Clang 9.0.0 (clang-900.0.39.2)]\n",
-    "```"
+    "from dataclasses import dataclass\n",
+    "\n",
+    "@dataclass(frozen=True)\n",
+    "class Point:\n",
+    "    x: float\n",
+    "    y: float\n",
+    "\n",
+    "    def __eq__(self, other):\n",
+    "        return self.x == other.x and self.y == other.y\n",
+    "\n",
+    "    def __hash__(self):\n",
+    "        return (11 * self.x + self.y) // 16"
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "```python\n",
-    ">>> from dataclasses import dataclass\n",
-    ">>>\n",
-    ">>> @dataclass(frozen=True)\n",
-    "... class Point:\n",
-    "...     x: float\n",
-    "...     y: float\n",
-    "...\n",
-    "...     def __eq__(self, other):\n",
-    "...         return self.x == other.x and self.y == other.y\n",
-    "...\n",
-    "...     def __hash__(self):\n",
-    "...         return (11 * self.x + self.y) // 16\n",
-    "...\n",
-    ">>> p1, p2, p3 = Point(1, 1), Point(1, 1), Point(1, 1)\n",
-    ">>>\n",
-    ">>> s = {p1, p2}\n",
-    ">>> len(s)\n",
-    "1\n",
-    ">>>\n",
-    ">>> p3 in s\n",
-    "True\n",
-    ">>>\n",
-    ">>> try:\n",
-    "...     p1.x = 10\n",
-    "... except Exception as e:\n",
-    "...     print(f\"OOPS {type(e)}\")\n",
-    "...\n",
-    "OOPS <class 'dataclasses.FrozenInstanceError'>\n",
-    "```"
+    "p1, p2, p3 = Point(1, 1), Point(1, 1), Point(1, 1)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "s = {p1, p2}\n",
+    "len(s)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "p3 in s"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "try:\n",
+    "    p1.x = 10\n",
+    "except Exception as e:\n",
+    "    print(f\"OOPS {type(e)}\")"
    ]
   },
   {


### PR DESCRIPTION
Now that Python 3.7 is available on the plateform, anyone should be able
to execute it online.

Le code suivant exécuté dans un notebook sur la plateforme actuelle
semble confirmer que la limite à 3.6 n’est plus nécessaire :
``` python
import sys; print(sys.version)
```
```
3.7.1 | packaged by conda-forge | (default, Feb 26 2019, 04:48:14) 
[GCC 7.3.0]
```