### PR TITLE
fait de int_to_char une fonction nichée

### DIFF
--- a/modules/corrections/exo_spreadsheet.py
+++ b/modules/corrections/exo_spreadsheet.py
@@ -2,26 +2,25 @@ from nbautoeval.exercise_function import ExerciseFunction
 from nbautoeval.args import Args
 
 # @BEG@ name=spreadsheet
-def int_to_char(n):
-    """
-    traduit un entier entre 1 et 26 
-    en un caractère entre 'A' et 'Z'
-    """
-    # si index était compris entre 0 et 25, on pourrait obtenir
-    # la lettre comme étant chr(ord('A') + index)
-    # on fait donc un changement de variable n -> n-1
-    # de plus on va rendre le résultat cyclique modulo 26
-    # pour pouvoir l'utiliser sur des nombres quelconques
-
-    return chr(ord('A') + (n - 1) % 26)
-
-
 def spreadsheet(index):
     """
     transforme un numéro de colonne en nom alphabétique
     dans l'ordre lexicographique
     1 -> A; 26 -> Z; 27 -> AA; 28 -> AB; etc..
     """
+    def int_to_char(n):
+        """
+        traduit un entier entre 1 et 26 
+        en un caractère entre 'A' et 'Z'
+        """
+        # si index était compris entre 0 et 25, on pourrait obtenir
+        # la lettre comme étant chr(ord('A') + index)
+        # on fait donc un changement de variable n -> n-1
+        # de plus on va rendre le résultat cyclique modulo 26
+        # pour pouvoir l'utiliser sur des nombres quelconques
+
+        return chr(ord('A') + (n - 1) % 26)
+
     # index peut être supérieur à 26
     # en remarquant que la dernière lettre s'incrémente à chaque fois 
     # qu'index augmente, et repasse à 'A' de manière cyclique, 

--- a/modules/corrections/exo_spreadsheet.py
+++ b/modules/corrections/exo_spreadsheet.py
@@ -10,7 +10,7 @@ def spreadsheet(index):
     """
     def int_to_char(n):
         """
-        traduit un entier entre 1 et 26 
+        traduit un entier entre 1 et 26
         en un caractère entre 'A' et 'Z'
         """
         # si index était compris entre 0 et 25, on pourrait obtenir
@@ -22,11 +22,11 @@ def spreadsheet(index):
         return chr(ord('A') + (n - 1) % 26)
 
     # index peut être supérieur à 26
-    # en remarquant que la dernière lettre s'incrémente à chaque fois 
-    # qu'index augmente, et repasse à 'A' de manière cyclique, 
-    # on voit qu'on peut utiliser notre version cyclique de `int_to_char` 
+    # en remarquant que la dernière lettre s'incrémente à chaque fois
+    # qu'index augmente, et repasse à 'A' de manière cyclique,
+    # on voit qu'on peut utiliser notre version cyclique de `int_to_char`
     # pour calculer la lettre la plus à droite dans le résultat.
-    # et pour les autres lettres, il suffit de recommencer sur le quotient 
+    # et pour les autres lettres, il suffit de recommencer sur le quotient
 
     result = int_to_char(index)
     while index > 26:
@@ -46,9 +46,9 @@ def spreadsheet_bis(index):
     est bien un entier supérieur à 0.
     """
     if not isinstance(index, int):
-        raise TypeError("index must be an integer !")
+        raise TypeError("index must be an integer!")
     elif index < 1:
-        raise ValueError("index must be positive !")
+        raise ValueError("index must be positive!")
 
     result = chr(ord('A') + (index - 1) % 26)
     while index > 26:


### PR DESCRIPTION
La fonction int_to_char n'a pas besoin d'être exposée dans
l'espace de nommage global.
L'inclure dans spreadsheet permet également de montrer
un cas concret où il est pratique de définir une fonction
à l'intérieur d'une autre fonction.