### PR TITLE
conversion chiffre romain vers décimal plus exigeante

### DIFF
--- a/modules/corrections/cls_roman.py
+++ b/modules/corrections/cls_roman.py
@@ -150,7 +150,10 @@ class Roman:
                 # le soustraire à la valeur du symbole courant.
                 # C'est ainsi que fonctionne le système numérique romain.
                 if previous and Roman.isymbols[previous] < Roman.isymbols[r]:
-                    decimal -= 2 * Roman.isymbols[previous]
+                    if Roman.isymbols[r] // Roman.isymbols[previous] in (5, 10):
+                        decimal -= 2 * Roman.isymbols[previous]
+                    else:
+                        return nan
                 decimal += Roman.isymbols[r]
                 previous = r
         except KeyError:


### PR DESCRIPTION
Cette modification vérifie qu'une lettre qui suit une lettre de valeur plus petite a bien une valeur 5 ou 10 fois plus grande seulement.
Par exemple, avec cette modification, "MIM" ne serait pas considérée comme un chiffre romain.

Adrien